### PR TITLE
Arrumando US01 de acordo com comentários do PO

### DIFF
--- a/src/components/CustomAccordion/index.tsx
+++ b/src/components/CustomAccordion/index.tsx
@@ -21,13 +21,12 @@ export default function CustomAccordion({
   return (
     <Accordion
       marginBottom={marginBottom}
-      defaultIndex={[0]}
       allowMultiple
       width="100%"
       backgroundColor="#FFF"
       borderRadius="8px"
     >
-      <AccordionItem>
+      <AccordionItem border="hidden">
         <h2>
           <AccordionButton>
             <AccordionIcon />

--- a/src/components/ExportExcel/index.tsx
+++ b/src/components/ExportExcel/index.tsx
@@ -1,4 +1,4 @@
-import { Button, Flex, Image } from "@chakra-ui/react";
+import { Button, Flex, Text } from "@chakra-ui/react";
 import * as XLSX from "xlsx";
 
 interface ExportExcelProps {
@@ -19,7 +19,7 @@ const ExportExcel = ({ excelData, fileName }: ExportExcelProps) => {
   return (
     <Flex marginRight="1em">
       <Button onClick={exportToExcel} colorScheme="blue" size="md">
-        <Image width="3.5em" src="src/images/spreadsheet-file-icon.png" />
+        <Text> XLSX </Text>
       </Button>
     </Flex>
   );

--- a/src/pages/Statistics/index.tsx
+++ b/src/pages/Statistics/index.tsx
@@ -51,6 +51,7 @@ export default function Statistics() {
       setSelectedFlow(-1);
       setShowProcesses(false);
       setOpenSelectFlow(true);
+      setOpenChart(false);
     };
   }, []);
 
@@ -86,6 +87,7 @@ export default function Statistics() {
   const [totalPages, setTotalPages] = useState(0);
   const [loading, setLoading] = useState(false);
   const [openSelectFlow, setOpenSelectFlow] = useState(false);
+  const [openChart, setOpenChart] = useState(false);
   const limit = 5;
 
   const tableColumnHelper = createColumnHelper<TableRow<any>>();
@@ -359,6 +361,7 @@ export default function Statistics() {
                         setOpenSelectStage(true);
                         handleConfirmSelectionFlow();
                         setShowProcesses(false);
+                        setOpenChart(true);
                       }}
                     >
                       Confirmar
@@ -387,6 +390,7 @@ export default function Statistics() {
                           onClick={() => {
                             setOpenSelectStage(true);
                             handleConfirmSelectionStages();
+                            setOpenChart(false);
                           }}
                         >
                           Confirmar
@@ -434,18 +438,22 @@ export default function Statistics() {
                     </Flex>
                   ) : (
                     <Flex flexDir="column">
-                      <Grid
-                        w="50%"
-                        h="30%"
-                        marginLeft="3.2%"
-                        marginTop="57.12px"
-                      >
-                        <BarChart
-                          id="chart-etapas-fluxo"
-                          selectedFlow={selectedFlow}
-                          chartData={chartData}
-                        />
-                      </Grid>
+                      {openChart ? (
+                        <Grid
+                          w="50%"
+                          h="30%"
+                          marginLeft="3.2%"
+                          marginTop="57.12px"
+                        >
+                          <BarChart
+                            id="chart-etapas-fluxo"
+                            selectedFlow={selectedFlow}
+                            chartData={chartData}
+                          />
+                        </Grid>
+                      ) : (
+                        <></>
+                      )}
                     </Flex>
                   )}
                 </>

--- a/src/pages/Statistics/index.tsx
+++ b/src/pages/Statistics/index.tsx
@@ -305,7 +305,7 @@ export default function Statistics() {
         {
           barPercentage: 0.6,
           barThickness: "flex",
-          label: "Etapas",
+          label: "Processos",
           data: Object.values(stages).map((stage) => stage.countProcess),
           backgroundColor: generateColorTransition(
             "#FF0000",

--- a/src/pages/Statistics/index.tsx
+++ b/src/pages/Statistics/index.tsx
@@ -11,7 +11,6 @@ import {
   useToast,
   Select,
   Grid,
-  Image,
 } from "@chakra-ui/react";
 import { ViewIcon } from "@chakra-ui/icons";
 import { createColumnHelper } from "@tanstack/react-table";
@@ -51,6 +50,7 @@ export default function Statistics() {
       setOpenSelectStage(false);
       setSelectedFlow(-1);
       setShowProcesses(false);
+      setOpenSelectFlow(true);
     };
   }, []);
 
@@ -85,7 +85,8 @@ export default function Statistics() {
   const [currentPage, setCurrentPage] = useState(0);
   const [totalPages, setTotalPages] = useState(0);
   const [loading, setLoading] = useState(false);
-  const limit = 3;
+  const [openSelectFlow, setOpenSelectFlow] = useState(false);
+  const limit = 5;
 
   const tableColumnHelper = createColumnHelper<TableRow<any>>();
 
@@ -216,6 +217,7 @@ export default function Statistics() {
 
   const handleConfirmSelectionFlow = async () => {
     if (selectedFlow >= 0) {
+      setOpenSelectFlow(true);
       setOpenSelectStage(true);
 
       const stagesResult = await getCountProcessByIdFlow(selectedFlow);
@@ -253,7 +255,7 @@ export default function Statistics() {
         setTotalPages(total ?? 0);
       } else {
         toast({
-          id: "error-getting-stages",
+          id: "error-getting-process",
           title: "Erro ao buscar processos",
           description: "Houve um erro ao buscar processos.",
           status: "error",
@@ -335,56 +337,85 @@ export default function Statistics() {
               title="Visualizar quantidade de processos em cada etapa"
               marginBottom={18}
             >
-              {openSelectStage ? (
+              {openSelectFlow ? (
                 <>
-                  <Flex alignItems="center">
+                  <Flex>
                     <Select
-                      placeholder="Selecione a etapa"
+                      placeholder="Selecione o fluxo"
                       marginLeft="36px"
                       width="302px"
-                      onChange={(e) => {
-                        setSelectedStage(Number(e.target.value));
-                        setCurrentPage(0);
-                      }}
+                      onChange={(e) => setSelectedFlow(Number(e.target.value))}
                     >
-                      {Object.values(stages).map((stage) => (
-                        <option key={stage.idStage} value={stage.idStage}>
-                          {stage.name}
+                      {flowsData?.value?.map((flow: any) => (
+                        <option value={flow.idFlow} key={flow.name}>
+                          {flow.name}
                         </option>
                       ))}
                     </Select>
                     <Button
                       colorScheme="green"
-                      marginLeft="20px"
-                      marginRight="42%"
+                      marginLeft="10px"
                       onClick={() => {
-                        setOpenSelectStage(false);
-                        handleConfirmSelectionStages();
+                        setOpenSelectStage(true);
+                        handleConfirmSelectionFlow();
+                        setShowProcesses(false);
                       }}
                     >
                       Confirmar
                     </Button>
-                    <Flex>
-                      {showProcesses && (
-                        <ExportExcel
-                          excelData={filteredProcess}
-                          fileName={`Processos_do_fluxo_${selectedFlow}_na_etapa_${selectedStage}`}
-                        />
-                      )}
-                      <Flex marginRight="30%">
-                        <Button
-                          onClick={
-                            showProcesses
-                              ? () => DownloadPDFProcess()
-                              : DownloadPDFChart
-                          }
-                          colorScheme="blue"
-                          size="md"
+                    {openSelectStage ? (
+                      <Flex alignItems="center">
+                        <Select
+                          placeholder="Selecione a etapa"
+                          marginLeft="36px"
+                          width="302px"
+                          onChange={(e) => {
+                            setSelectedStage(Number(e.target.value));
+                            setCurrentPage(0);
+                          }}
                         >
-                          <Image width="3em" src="src/images/pdf.svg" />
+                          {Object.values(stages).map((stage) => (
+                            <option key={stage.idStage} value={stage.idStage}>
+                              {stage.name}
+                            </option>
+                          ))}
+                        </Select>
+                        <Button
+                          colorScheme="green"
+                          marginLeft="10px"
+                          marginRight="10%"
+                          onClick={() => {
+                            setOpenSelectStage(true);
+                            handleConfirmSelectionStages();
+                          }}
+                        >
+                          Confirmar
                         </Button>
+                        <Flex>
+                          {showProcesses && (
+                            <ExportExcel
+                              excelData={filteredProcess}
+                              fileName={`Processos_do_fluxo_${selectedFlow}_na_etapa_${selectedStage}`}
+                            />
+                          )}
+                          <Flex marginRight="30%">
+                            <Button
+                              onClick={
+                                showProcesses
+                                  ? () => DownloadPDFProcess()
+                                  : DownloadPDFChart
+                              }
+                              colorScheme="blue"
+                              size="md"
+                            >
+                              <Text fontSize="16px"> PDF </Text>
+                            </Button>
+                          </Flex>
+                        </Flex>
                       </Flex>
-                    </Flex>
+                    ) : (
+                      <></>
+                    )}
                   </Flex>
                   {showProcesses ? (
                     <Flex flexDir="column" alignItems="center" marginTop="2%">
@@ -419,30 +450,7 @@ export default function Statistics() {
                   )}
                 </>
               ) : (
-                <Flex>
-                  <Select
-                    placeholder="Selecione o fluxo"
-                    marginLeft="36px"
-                    width="302px"
-                    onChange={(e) => setSelectedFlow(Number(e.target.value))}
-                  >
-                    {flowsData?.value?.map((flow: any) => (
-                      <option value={flow.idFlow} key={flow.name}>
-                        {flow.name}
-                      </option>
-                    ))}
-                  </Select>
-                  <Button
-                    colorScheme="green"
-                    marginLeft="20px"
-                    onClick={() => {
-                      setOpenSelectStage(true);
-                      handleConfirmSelectionFlow();
-                    }}
-                  >
-                    Confirmar
-                  </Button>
-                </Flex>
+                <></>
               )}
             </CustomAccordion>
           </Flex>


### PR DESCRIPTION
## Issue

Closes fga-eps-mds/2023-2-CAPJu-Doc#14

## Descrição

Esta branch foi feita para resolver os comentários do PO no Zenhub. Agora será possível visualizar o fluxo que foi selecionado mesmo depois de apertar o botão confirmar.  O select de selecionar etapas ficará disposto ao lado do select fluxo podendo agora selecionar fluxo e etapa de forma mais flexível, pois mesmo depois de selecionar o fluxo, além de poder ver o que você selecionou será possível alterar mesmo depois de confirmado, o que não era possível anteriormente. Nos botões de download, ao invés de de imagens foi trocado para texto em relação so "PDF" e "XLSX". E assim como foi comentado, ao passsar o mouse no gráfico irá aparecer "Processos" e a quantidade de processos na etapa, pois antes estava "Etapas".

## Revisão 
- [ ] Ao iniciar a página aparecer somente o selecionar fluxo
- [ ] Após selecionar fluxo, aparecer o gráfico correto, o select de etapas ao lado e o botão de PDF
- [ ] Ao selecionar etapa aparecer os processo que estão na etapa selecionada, o botão de XLSX e PDF
- [ ] Poder mudar o fluxo selecionado mesmo após já ter selecionado uma etapa
- [ ] O botão de XLSX desaparece após selecionar um  fluxo

## Pre-merge checklist 

- [ ] O Pull Request refere-se a um único assunto, um título claro e uma descrição em frases gramaticalmente corretas e completas.
- [ ] A ramificação está atualizada com a branch Develop.
- [ ] Os commits atendem o padrão especificado na política de contribuição.