### PR TITLE
Bug de paginacao de processos

### DIFF
--- a/src/pages/Processes/index.tsx
+++ b/src/pages/Processes/index.tsx
@@ -290,7 +290,12 @@ function Processes() {
 
   useEffect(() => {
     refetchProcesses();
-  }, [currentPage, showFinished, legalPriority]);
+  }, [currentPage]);
+
+  useEffect(() => {
+    setCurrentPage(0);
+    refetchProcesses();
+  }, [legalPriority, showFinished]);
 
   const [placeholder, setPlaceholder] = useState<string>(
     "Pesquisar processos (por registro ou apelido)"


### PR DESCRIPTION
## Issue

Paginação da página de Processos não era resetada ao selecionar "Processos apenas processos com prioridade legal" ou "Mostrar processos concluídos / interrompidos". Se você estivesse na página 2 de processos e clicasse, por exemplo, em "Mostrar processos concluídos / interrompidos", era mostrado na tela a página 2 dos processos concluídos e interrompidos. Foi criado um userEffect pra zerar paginacao e dar refresh nos processos, voltando corretamente pra pagina inicial.

## Descrição

<!-- Descreve precisamente o que está sendo submetido e suas alterações -->

## Revisão 
<!-- Verifica se os critérios estabelecidos na issue foram realizados -->
- [ ] Entrar na segunda pagina de processos (ou mais)
- [ ] Marcar o "mostrar processos com prioridade"
- [ ] Tirar a marcação do "mostrar processos com prioridade"
- [ ] A lista de processos voltar pra primeira página

