### PR TITLE
Corrigindo ordenação inicial de etapas ao editar fluxos.

### DIFF
--- a/src/pages/Flows/EditionModal/index.tsx
+++ b/src/pages/Flows/EditionModal/index.tsx
@@ -15,13 +15,13 @@ import {
 import * as yup from "yup";
 import { useForm } from "react-hook-form";
 import { yupResolver } from "@hookform/resolvers/yup";
-
 import { updateFlow } from "services/processManagement/flows";
 import { getStages } from "services/processManagement/stage";
 import { getAcceptedUsers } from "services/user";
 import { Input, MultiSelect } from "components/FormFields";
 import { Flow } from "components/Flow";
 import { useLoading } from "hooks/useLoading";
+import { sortFlowStages } from "../../../utils/sorting";
 
 type FormValues = {
   name: string;
@@ -64,8 +64,11 @@ export function EditionModal({
     refetchOnWindowFocus: false,
   });
   const [selectedStages, setSelectedStages] = useState<Stage[]>(
-    stagesData?.value?.filter((item) =>
-      flow.stages.some((stageId) => stageId === item.idStage)
+    sortFlowStages(
+      stagesData?.value?.filter((item) =>
+        flow.stages.some((stageId) => stageId === item.idStage)
+      ) || [],
+      flow.sequences
     ) || []
   );
   const [usersToNotify, setUsersToNotify] = useState<(number | string)[]>([]);


### PR DESCRIPTION
## Issue

Closes fga-eps-mds/2023-2-CAPJu-Doc#159
## Descrição

Corrige o bug descrito na issue acima.

## Revisão 
<!-- Verifica se os critérios estabelecidos na issue foram realizados -->
- [ ] Crie uma etapa A
- [ ] Crie uma etapa B
- [ ] Crie um fluxo BA com as etapas B e A, nesta ordem.
- [ ] Crie um processo com  este fluxo.
- [ ] Clique em editar fluxo e verifique se a ordem esta a estabelecida para o fluxo.

