### PR TITLE
Ajustando para mostrar por default so processos de dois anos ate a da…

### DIFF
--- a/src/pages/Statistics/FilteringProcesses/index.tsx
+++ b/src/pages/Statistics/FilteringProcesses/index.tsx
@@ -176,8 +176,8 @@ export default function FilteringProcesses() {
       filter,
       false,
       selectedStatus === "" ? ["archived", "finished"] : [selectedStatus],
-      fromDate === "" ? undefined : fromDate,
-      toDate === "" ? undefined : toDate
+      fromDate === "" ? twoYearsAgoDate : fromDate,
+      toDate === "" ? today : toDate
     );
 
     if (response.type === "success") {


### PR DESCRIPTION
Arrumando pra mostrar por default quando abre a estatistica apenas os processos concluidos/interrompidos dos ultimos 2 anos a partir da data atual